### PR TITLE
Windows version independency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Different LIME Toolbox versions can coexist in the same Windows system, allowing users to switch between releases
+  without conflicts.
 - Added support for Python 3.13 and 3.14
 - Added configuration overrides for appdata and programfiles paths (`APPDATA_OVERRIDE`, `PROGRAMFILES_OVERRIDE`) to
   support integration with external systems directly through python package installation.

--- a/deployment/installer/windows/inno_installer_builder.iss
+++ b/deployment/installer/windows/inno_installer_builder.iss
@@ -3,7 +3,7 @@
 
 #define MyAppName "LimeTBX"
 #define MyAppVersion "1.4.1"
-#define MyFullAppName "{#MyAppName}_{#MyAppVersion}"
+#define MyFullAppName "{#MyAppName} {#MyAppVersion}"
 #define MyAppPublisher "European Space Agency"
 #define MyAppExeName "LimeTBX_GUI.exe"
 #define MyAppDevPath "C:\repo\"

--- a/deployment/installer/windows/inno_installer_builder.iss
+++ b/deployment/installer/windows/inno_installer_builder.iss
@@ -3,6 +3,7 @@
 
 #define MyAppName "LimeTBX"
 #define MyAppVersion "1.4.1"
+#define MyFullAppName "{#MyAppName}_{#MyAppVersion}"
 #define MyAppPublisher "European Space Agency"
 #define MyAppExeName "LimeTBX_GUI.exe"
 #define MyAppDevPath "C:\repo\"
@@ -12,12 +13,12 @@
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{BA556966-3F6F-4065-8A45-BF787E56A6DF}}
+AppId={{BA556966-3F6F-4065-8A45-BF787E56A6DF}_{#MyAppVersion}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
-DefaultDirName={autopf64}\{#MyAppName}
+DefaultDirName={autopf64}\{#MyFullAppName}
 DisableProgramGroupPage=yes
 ArchitecturesAllowed=x64compatible
 PrivilegesRequired=admin
@@ -51,16 +52,16 @@ Source: "{#MyAppDevPath}\kernels\*"; DestDir: "{app}\kernels"; Flags: ignorevers
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\LimeTBX\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\LimeTBX\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyFullAppName}"; Filename: "{app}\LimeTBX\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyFullAppName}"; Filename: "{app}\LimeTBX\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\LimeTBX\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
 [Registry]
 Root: HKLM64; Subkey: "SOFTWARE\ESA"; Flags: uninsdeletekeyifempty; Check: IsWin64
-Root: HKLM64; Subkey: "SOFTWARE\ESA\{#MyAppName}"; Flags: uninsdeletekey; Check: IsWin64
-Root: HKLM64; Subkey: "SOFTWARE\ESA\{#MyAppName}\Settings"; Flags: createvalueifdoesntexist; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"; Check: IsWin64
+Root: HKLM64; Subkey: "SOFTWARE\ESA\{#MyFullAppName}"; Flags: uninsdeletekey; Check: IsWin64
+Root: HKLM64; Subkey: "SOFTWARE\ESA\{#MyFullAppName}\Settings"; Flags: createvalueifdoesntexist; ValueType: string; ValueName: "InstallPath"; ValueData: "{app}"; Check: IsWin64
 Root: HKLM64; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\LimeTBX\bin"
 
 [UninstallDelete]

--- a/deployment/installer/windows/inno_installer_builder.iss
+++ b/deployment/installer/windows/inno_installer_builder.iss
@@ -3,7 +3,7 @@
 
 #define MyAppName "LimeTBX"
 #define MyAppVersion "1.4.1"
-#define MyFullAppName "{#MyAppName} {#MyAppVersion}"
+#define MyFullAppName MyAppName + " " + MyAppVersion
 #define MyAppPublisher "European Space Agency"
 #define MyAppExeName "LimeTBX_GUI.exe"
 #define MyAppDevPath "C:\repo\"

--- a/lime_tbx/persistence/local_storage/appdata.py
+++ b/lime_tbx/persistence/local_storage/appdata.py
@@ -13,6 +13,7 @@ import os
 from logging import Logger
 
 import lime_tbx.persistence.local_storage.config_paths as config_paths
+from lime_tbx import __version__
 
 
 APPNAME = "LimeTBX"
@@ -70,7 +71,8 @@ def _get_appdata_folder(logger: Logger, platform: str) -> str:
         appdata = str(home / "Library/Application Support" / APPNAME)
     elif platform == "win32":
         appdata = path.join(
-            os.environ.get("APPDATA", path.join(os.getcwd(), "appdata")), APPNAME
+            os.environ.get("APPDATA", path.join(os.getcwd(), "appdata")),
+            f"{APPNAME}_{__version__}",
         )
     else:
         appdata = path.expanduser(path.join("~", "." + APPNAME))

--- a/lime_tbx/persistence/local_storage/programdata.py
+++ b/lime_tbx/persistence/local_storage/programdata.py
@@ -12,6 +12,7 @@ import os
 from lime_tbx.common import logger
 from lime_tbx.persistence.local_storage import appdata
 import lime_tbx.persistence.local_storage.config_paths as config_paths
+from lime_tbx import __version__
 
 APPNAME = "LimeTBX"
 
@@ -47,24 +48,23 @@ def get_programfiles_folder() -> str:
         import winreg
 
         programfiles = ""
+        fullappname = f"{APPNAME}_{__version__}"
         a_reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
         valid = True
         try:
-            sub_key_install_folder = "SOFTWARE\\ESA\\LimeTBX\\Settings"
+            sub_key_install_folder = f"SOFTWARE\\ESA\\{fullappname}\\Settings"
             a_key = winreg.OpenKey(a_reg, sub_key_install_folder)
             programfiles = winreg.QueryValueEx(a_key, "InstallPath")[0]
         except:
             valid = False
         if not valid:  # Search for admin uninstall key
-            sub_key_admin = (
-                "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\LimeTBX_is1"
-            )
+            sub_key_admin = f"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{fullappname}_is1"
             try:
                 a_key = winreg.OpenKey(a_reg, sub_key_admin)
             except:
                 valid = False
             if not valid:  # Search for user uninstall key
-                sub_key_user = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\LimeTBX_is1"
+                sub_key_user = f"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{fullappname}_is1"
                 a_reg = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
                 valid = True
                 try:
@@ -77,8 +77,8 @@ def get_programfiles_folder() -> str:
                 except:
                     valid = False
         if not valid:
-            log.warning("Did not find LimeTBX key in winreg registry.")
-            programfiles = path.join(os.environ["PROGRAMFILES"], APPNAME)
+            log.warning(f"Did not find {fullappname} key in winreg registry.")
+            programfiles = path.join(os.environ["PROGRAMFILES"], fullappname)
     else:
         programfiles = path.join("/opt/esa", APPNAME)
     log.debug("Programfiles: {}".format(programfiles))

--- a/lime_tbx/persistence/local_storage/programdata.py
+++ b/lime_tbx/persistence/local_storage/programdata.py
@@ -48,7 +48,7 @@ def get_programfiles_folder() -> str:
         import winreg
 
         programfiles = ""
-        fullappname = f"{APPNAME}_{__version__}"
+        fullappname = f"{APPNAME} {__version__}"
         a_reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
         valid = True
         try:

--- a/lime_tbx/persistence/local_storage/programdata.py
+++ b/lime_tbx/persistence/local_storage/programdata.py
@@ -48,7 +48,7 @@ def get_programfiles_folder() -> str:
         import winreg
 
         programfiles = ""
-        fullappname = f"{APPNAME} {__version__}"
+        fullappname = f"{APPNAME} {'.'.join(__version__.split('.')[:3])}"
         a_reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
         valid = True
         try:


### PR DESCRIPTION
### Added

- Different LIME Toolbox versions can coexist in the same Windows system, allowing users to switch between releases
  without conflicts.